### PR TITLE
Don't prefix trx report options unnecessarily

### DIFF
--- a/src/dotnet-retest/RetestCommand.cs
+++ b/src/dotnet-retest/RetestCommand.cs
@@ -216,7 +216,7 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
         #region trx
 
         [Description("Include test output in report")]
-        [CommandOption("--trx-output")]
+        [CommandOption("--output")]
         [DefaultValue(false)]
         public bool Output { get; init; }
 
@@ -224,7 +224,7 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
         /// Whether to include skipped tests in the output.
         /// </summary>
         [Description("Include skipped tests in report")]
-        [CommandOption("--trx-skipped")]
+        [CommandOption("--skipped")]
         [DefaultValue(true)]
         public bool Skipped { get; init; } = true;
 
@@ -232,7 +232,7 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
         /// Report as GitHub PR comment.
         /// </summary>
         [Description("Report as GitHub PR comment")]
-        [CommandOption("--trx-gh-comment")]
+        [CommandOption("--gh-comment")]
         [DefaultValue(true)]
         public bool GitHubComment { get; init; } = true;
 
@@ -240,7 +240,7 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
         /// Report as GitHub PR comment.
         /// </summary>
         [Description("Report as GitHub step summary")]
-        [CommandOption("--trx-gh-summary")]
+        [CommandOption("--gh-summary")]
         [DefaultValue(true)]
         public bool GitHubSummary { get; init; } = true;
 

--- a/src/dotnet-retest/help.md
+++ b/src/dotnet-retest/help.md
@@ -3,12 +3,12 @@ USAGE:
     dotnet retest [OPTIONS] [-- [dotnet test options]]
 
 OPTIONS:
-                            DEFAULT                                   
-    -h, --help                         Prints help information        
-    -v, --version                      Prints version information     
-        --attempts          5          Maximum attempts to run tests  
-        --trx-output                   Include test output in report  
-        --trx-skipped       True       Include skipped tests in report
-        --trx-gh-comment    True       Report as GitHub PR comment    
-        --trx-gh-summary    True       Report as GitHub step summary  
+                        DEFAULT                                   
+    -h, --help                     Prints help information        
+    -v, --version                  Prints version information     
+        --attempts      5          Maximum attempts to run tests  
+        --output                   Include test output in report  
+        --skipped       True       Include skipped tests in report
+        --gh-comment    True       Report as GitHub PR comment    
+        --gh-summary    True       Report as GitHub step summary  
 ```


### PR DESCRIPTION
Since the user may not even be aware that there's a standalone tool called trx that does the same test reporting.