### PR TITLE
Improve progress reporting by showing output

### DIFF
--- a/src/dotnet-retest/Properties/launchSettings.json
+++ b/src/dotnet-retest/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "dotnet-retest": {
       "commandName": "Project",
-      "commandLineArgs": "-- ..\\Samples",
-      "workingDirectory": "C:\\Code\\dotnet-retest\\src\\dotnet-retest"
+      "commandLineArgs": "-- ..\\Sample\\Sample.csproj",
+      "workingDirectory": "."
     }
   }
 }


### PR DESCRIPTION
While running `dotnet test`, add its output as part of the overal task progress.

Add elapsed time for each attempt, as well as spinner progress.