### PR TITLE
Allow for extra loggers in addition to trx

### DIFF
--- a/src/dotnet-retest/Properties/launchSettings.json
+++ b/src/dotnet-retest/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "dotnet-retest": {
       "commandName": "Project",
-      "commandLineArgs": "-- ..\\Sample\\Sample.csproj",
+      "commandLineArgs": "-- ..\\Sample\\Sample.csproj --logger \"html;logfilename=testResults.html\" --results-directory bin",
       "workingDirectory": "."
     }
   }

--- a/src/dotnet-retest/RetestCommand.cs
+++ b/src/dotnet-retest/RetestCommand.cs
@@ -23,9 +23,6 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
 
     public override async Task<int> ExecuteAsync(CommandContext context, RetestSettings settings)
     {
-        string? path = null;
-        string? logger = null;
-
         var args = context.Remaining.Raw.ToList();
         // A typical mistake would be to pass dotnet test args directly without the -- separator
         // so account for this automatically so users fall in the pit of success
@@ -43,9 +40,12 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
             }
         }
 
+        string? path = null;
+        var hastrx = false;
+
         new OptionSet
         {
-            { "l|logger=", v => logger = v },
+            { "l|logger=", v => hastrx = v.StartsWith("trx") },
             { "results-directory=", v => path = v },
         }.Parse(args);
 
@@ -65,12 +65,8 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
             args.Insert(1, trx.Path);
         }
 
-        if (logger != null && !logger.StartsWith("trx"))
-        {
-            WriteLine($"[red]Error:[/] Unsupported logger {logger}. Use 'trx' or omit entirely.");
-            return -1;
-        }
-        else if (logger == null)
+        // Ensure we add the trx logger. Note that there can be other loggers too
+        if (!hastrx)
         {
             args.Insert(0, "--logger");
             args.Insert(1, "trx");

--- a/src/dotnet-retest/dotnet-retest.csproj
+++ b/src/dotnet-retest/dotnet-retest.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Devlooped</RootNamespace>
     <AssemblyName>retest</AssemblyName>
+    <NoWarn>CS9107</NoWarn>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
 
     <PackageId>dotnet-retest</PackageId>


### PR DESCRIPTION
dotnet-test allows multiple loggers to be specified, so we should not prevent that.