### PR TITLE
Increase console verbosity to get better progress

### DIFF
--- a/src/dotnet-retest/Properties/launchSettings.json
+++ b/src/dotnet-retest/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "dotnet-retest": {
       "commandName": "Project",
-      "commandLineArgs": "-- ..\\Sample\\Sample.csproj --logger \"html;logfilename=testResults.html\" --results-directory bin",
-      "workingDirectory": "."
+      "commandLineArgs": "",
+      "workingDirectory": "..\\Sample"
     }
   }
 }


### PR DESCRIPTION
If no console logger is specified, add one with normal verbosity to increase from the default minimal.