### PR TITLE
Rename attempts to retries

### DIFF
--- a/src/dotnet-retest/RetestCommand.cs
+++ b/src/dotnet-retest/RetestCommand.cs
@@ -117,6 +117,7 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
             {
                 attempts++;
                 var task = ctx.AddTask($"Running tests, attempt #{attempts}");
+
                 try
                 {
                     task.StartTask();
@@ -126,9 +127,9 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
                     if (attempts > 1 && !args.Contains("--no-build"))
                         args.Insert(0, "--no-build");
 
-                    var prefix = failed.Count > 0 ?
-                        $"Running {failed.Count} tests, attempt [yellow]#{attempts}[/]" :
-                        $"Running tests, attempt #{attempts}";
+                    var prefix = attempts == 1 ?
+                        $"Running tests" :
+                        $"Retrying {failed.Count} failed test{(failed.Count > 1 ? "s" : "")}";
 
                     task.Description = prefix;
 
@@ -272,10 +273,18 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
 
     public class RetestSettings : CommandSettings
     {
+        [Description("Maximum retries when re-running failed tests")]
+        [CommandOption("--retries")]
+        [DefaultValue(3)]
+        public int Retries
+        {
+            get => Attempts - 1;
+            init => Attempts = value + 1;
+        }
+
         [Description("Maximum attempts to run tests")]
-        [CommandOption("--attempts")]
-        [DefaultValue(5)]
-        public int Attempts { get; init; } = 5;
+        [CommandOption("--attempts", IsHidden = true)]
+        public int Attempts { get; init; }
 
         #region trx
 

--- a/src/dotnet-retest/help.md
+++ b/src/dotnet-retest/help.md
@@ -3,12 +3,12 @@ USAGE:
     dotnet retest [OPTIONS] [-- [dotnet test options]]
 
 OPTIONS:
-                        DEFAULT                                   
-    -h, --help                     Prints help information        
-    -v, --version                  Prints version information     
-        --attempts      5          Maximum attempts to run tests  
-        --output                   Include test output in report  
-        --skipped       True       Include skipped tests in report
-        --gh-comment    True       Report as GitHub PR comment    
-        --gh-summary    True       Report as GitHub step summary  
+                        DEFAULT                                                
+    -h, --help                     Prints help information                     
+    -v, --version                  Prints version information                  
+        --retries       3          Maximum retries when re-running failed tests
+        --output                   Include test output in report               
+        --skipped       True       Include skipped tests in report             
+        --gh-comment    True       Report as GitHub PR comment                 
+        --gh-summary    True       Report as GitHub step summary               
 ```


### PR DESCRIPTION
Much easier to remember the arg name and understand what it's about. In code, we still use attempts.

Also, reduce retries to 3, seems like a more sensible default (total attempts = 4 therefore, one less than before).

Make the task description cleaner