### PR TITLE
Add a way to opt-out of the summary

### DIFF
--- a/src/dotnet-retest/RetestCommand.cs
+++ b/src/dotnet-retest/RetestCommand.cs
@@ -188,7 +188,7 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
             WriteLine(runFailure.StandardOutput);
         }
 
-        if (Directory.Exists(trx.Path))
+        if (settings.NoSummary != true && Directory.Exists(trx.Path))
         {
             new TrxCommand().Execute(context, new TrxCommand.TrxSettings
             {
@@ -285,6 +285,11 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
         [Description("Maximum attempts to run tests")]
         [CommandOption("--attempts", IsHidden = true)]
         public int Attempts { get; init; }
+
+        [Description("Whether to emit a summary to console/GitHub")]
+        [CommandOption("--no-summary")]
+        [DefaultValue(false)]
+        public bool NoSummary { get; init; }
 
         #region trx
 

--- a/src/dotnet-retest/help.md
+++ b/src/dotnet-retest/help.md
@@ -7,6 +7,7 @@ OPTIONS:
     -h, --help                     Prints help information                     
     -v, --version                  Prints version information                  
         --retries       3          Maximum retries when re-running failed tests
+        --no-summary               Whether to emit a summary to console/GitHub 
         --output                   Include test output in report               
         --skipped       True       Include skipped tests in report             
         --gh-comment    True       Report as GitHub PR comment                 


### PR DESCRIPTION
Since this uses the dotnet-trx command, the easy way is to disable reporting entirely (which will also disable GH reporting).

Fixes #29