### PR TITLE
Send output directly to System.Console to avoid line breaks

### DIFF
--- a/src/dotnet-retest/RetestCommand.cs
+++ b/src/dotnet-retest/RetestCommand.cs
@@ -137,7 +137,7 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
                     {
                         if (ci)
                         {
-                            WriteLine(line.EscapeMarkup());
+                            System.Console.WriteLine(line);
                         }
                         else if (line.Trim() is { Length: > 0 } description)
                         {


### PR DESCRIPTION
Fixes: #54