### PR TITLE
Make retry logic more resilient to changes in xunit/vstest output

### DIFF
--- a/src/dotnet-retest/TrxCommand.cs
+++ b/src/dotnet-retest/TrxCommand.cs
@@ -19,6 +19,7 @@ namespace Devlooped;
 
 public partial class TrxCommand : Command<TrxCommand.TrxSettings>
 {
+    static readonly JsonSerializerOptions indentedJson = new() { WriteIndented = true };
     const string Header = "<!-- header -->";
     const string Footer = "<!-- footer -->";
 
@@ -72,22 +73,27 @@ public partial class TrxCommand : Command<TrxCommand.TrxSettings>
         [CommandOption("--gh-summary")]
         [DefaultValue(true)]
         public bool GitHubSummary { get; set; } = true;
+
+        public override ValidationResult Validate()
+        {
+            // Validate, normalize and default path.
+            var path = Path ?? Directory.GetCurrentDirectory();
+            if (!System.IO.Path.IsPathFullyQualified(path))
+                path = System.IO.Path.Combine(Directory.GetCurrentDirectory(), path);
+
+            Path = File.Exists(path) ? new FileInfo(path).DirectoryName! : System.IO.Path.GetFullPath(path);
+
+            return base.Validate();
+        }
     }
 
     public override int Execute(CommandContext context, TrxSettings settings)
     {
         if (Environment.GetEnvironmentVariable("RUNNER_DEBUG") == "1")
-            WriteLine(JsonSerializer.Serialize(new { settings }, new JsonSerializerOptions { WriteIndented = true }));
+            WriteLine(JsonSerializer.Serialize(new { settings }, indentedJson));
 
-        var path = settings.Path ?? Directory.GetCurrentDirectory();
-        if (!Path.IsPathFullyQualified(path))
-            path = Path.Combine(Directory.GetCurrentDirectory(), path);
-
-        if (File.Exists(path))
-            path = new FileInfo(path).DirectoryName!;
-        else
-            path = Path.GetFullPath(path);
-
+        // We get this validated by the settings, so it's always non-null.
+        var path = settings.Path!;
         var search = settings.Recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
         var testIds = new HashSet<string>();
         var passed = 0;

--- a/src/dotnet-retest/dotnet-retest.csproj
+++ b/src/dotnet-retest/dotnet-retest.csproj
@@ -41,7 +41,7 @@
 
   <Target Name="RenderHelp" AfterTargets="Build" Condition="$(DesignTimeBuild) != 'true'">
     <WriteLinesToFile Lines="```shell" Overwrite="true" Encoding="UTF-8" File="help.md" />
-    <Exec Command="dotnet run --no-build -- --help &gt;&gt; help.md" StdOutEncoding="UTF-8"
+    <Exec Command="dotnet run --no-build --no-launch-profile -- --help &gt;&gt; help.md" StdOutEncoding="UTF-8"
           EnvironmentVariables="NO_COLOR=true" />
     <WriteLinesToFile Lines="```" Overwrite="false" Encoding="UTF-8" File="help.md" />
   </Target>


### PR DESCRIPTION
There was a significant change in output from dotnet test/vstest/xunit which caused us to bail too early and not retry properly.

We know the output (for now?) will contain the phrasing `Results file: {path}\{filename}.trx`, but we don't want to make that detection too fragile either. So we just check for the presence of the directory we pass as results dir, which should be always available in standard output.

Fixes #48