### PR TITLE
Fix broken verbose reporting of successful tests

### DIFF
--- a/src/dotnet-retest/RetestCommand.cs
+++ b/src/dotnet-retest/RetestCommand.cs
@@ -73,6 +73,8 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
             Verbosity = settings.Verbosity,
             GitHubComment = settings.GitHubComment,
             GitHubSummary = settings.GitHubSummary,
+            Skipped = settings.Skipped,
+            Recursive = false,
         };
 
         if (trx.Validate() is { Successful: false } result)
@@ -201,15 +203,7 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
 
         if (settings.NoSummary != true && Directory.Exists(trx.Path))
         {
-            new TrxCommand().Execute(context, new TrxCommand.TrxSettings
-            {
-                GitHubComment = settings.GitHubComment,
-                GitHubSummary = settings.GitHubSummary,
-                Output = settings.Output,
-                Path = trx.Path,
-                Skipped = settings.Skipped,
-                Recursive = false,
-            });
+            new TrxCommand().Execute(context, trx);
         }
 
         return exitCode;


### PR DESCRIPTION
We werre missing passing through the verbosity setting to the trx command, because we were creating a brand new setting class after the fact.

Since all the logic in that settings class (defaulting the path) is encapsulated in the Validate method, we can safely just use it when running the command.

For dotnet-retest we never do recursive log lookup, and we should preserve the legacy Skipped setting if it's provided too.