### PR TITLE
Allow running on latest & greatest installed

### DIFF
--- a/src/dotnet-retest/dotnet-retest.csproj
+++ b/src/dotnet-retest/dotnet-retest.csproj
@@ -16,6 +16,9 @@
 
     <BuildDate>$([System.DateTime]::Now.ToString("yyyy-MM-dd"))</BuildDate>
     <BuildRef>$(GITHUB_REF_NAME)</BuildRef>
+
+    <!-- Allow running on whatever latest version users have. See https://docs.microsoft.com/en-us/dotnet/core/versions/selection#framework-dependent-apps-roll-forward -->
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This should allow it to run on .net9 only (and future versions too).

Fixes #87