### PR TITLE
Add support for pre-filtered lists of retest runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         run: dotnet tool update -g dotnet-retest --prerelease --add-source .
 
       - name: 🧪 test
-        run: dotnet retest -- ./src/Sample/
+        run: dotnet retest -- ./src/Sample/ --filter "FullyQualifiedName!=Sample.UnitTest1.FailsAlways"
 
       - name: 🐛 logs
         uses: actions/upload-artifact@v4

--- a/src/Sample/UnitTest1.cs
+++ b/src/Sample/UnitTest1.cs
@@ -2,6 +2,12 @@ namespace Sample;
 
 public class UnitTest1
 {
+    [Fact]
+    public void FailsAlways()
+    {
+        throw new InvalidOperationException("Always fails");
+    }
+
     [Theory]
     [InlineData(1)]
     [InlineData(2)]

--- a/src/dotnet-retest/Properties/launchSettings.json
+++ b/src/dotnet-retest/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "dotnet-retest": {
       "commandName": "Project",
-      "commandLineArgs": "",
+      "commandLineArgs": "-- --filter \"FullyQualifiedName!=Sample.UnitTest1.FailsAlways\"",
       "workingDirectory": "..\\Sample"
     }
   }

--- a/src/dotnet-retest/RetestCommand.cs
+++ b/src/dotnet-retest/RetestCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.CommandLine;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -147,7 +148,7 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
                         ctx.Refresh();
                     }
 
-                    var exit = await RunTestsAsync(DotnetMuxer.Path.FullName, new List<string>(args), failed, new Progress<string>(line =>
+                    var exit = await RunTestsAsync(DotnetMuxer.Path.FullName, [.. args], failed, new Progress<string>(line =>
                     {
                         if (ci)
                         {
@@ -247,14 +248,26 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
         return outcomes;
     }
 
+    static readonly RootCommand command = new()
+    {
+        Options =
+        {
+            new Option<string>("--filter")
+        }
+    };
+
     async Task<BufferedCommandResult> RunTestsAsync(string dotnet, List<string> args, IEnumerable<string> failed, IProgress<string> progress)
     {
-        var testArgs = string.Join(" ", args);
         var finalArgs = args;
         var filter = string.Join('|', failed.Select(failed => $"FullyQualifiedName~{failed}"));
         if (filter.Length > 0)
         {
-            testArgs = $"--filter \"{filter}\" {testArgs}";
+            var parsed = command.Parse(args);
+            if (parsed.GetValue<string>("--filter") is { } existing)
+            {
+                finalArgs = [.. parsed.UnmatchedTokens];
+                filter = $"({existing})&({filter})";
+            }
             finalArgs.InsertRange(0, ["--filter", filter]);
         }
 

--- a/src/dotnet-retest/dotnet-retest.csproj
+++ b/src/dotnet-retest/dotnet-retest.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="NuGetizer" Version="1.2.4" />
     <PackageReference Include="NuGet.Protocol" Version="6.13.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-rc.1.25451.107" />
     <PackageReference Include="ThisAssembly.Git" Version="2.0.12" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.Project" Version="2.0.12" PrivateAssets="all" />
   </ItemGroup>
@@ -47,8 +48,7 @@
 
   <Target Name="RenderHelp" AfterTargets="Build" Condition="$(NoHelp) != 'true' and $(DesignTimeBuild) != 'true'">
     <WriteLinesToFile Lines="```shell" Overwrite="true" Encoding="UTF-8" File="help.md" />
-    <Exec Command="dotnet run --no-build --no-launch-profile -- --help &gt;&gt; help.md" StdOutEncoding="UTF-8"
-          EnvironmentVariables="NO_COLOR=true" />
+    <Exec Command="dotnet run --no-build --no-launch-profile -- --help &gt;&gt; help.md" StdOutEncoding="UTF-8" EnvironmentVariables="NO_COLOR=true" />
     <WriteLinesToFile Lines="```" Overwrite="false" Encoding="UTF-8" File="help.md" />
   </Target>
 


### PR DESCRIPTION
We were previously failing to properly consider that `--filter` as a dotnet test option needs to be combined into a single switch (via `&` for logical and) rather than appended to args. Otherwise, dotnet fails to properly run and shows command help instead.

Fixes #91