### PR TITLE
Improve escaping sequences in test filters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,9 @@ jobs:
         run: dotnet tool update -g dotnet-retest --prerelease --add-source .
 
       - name: 🧪 test
-        run: dotnet retest -- ./src/Sample/ --filter "FullyQualifiedName!=Sample.UnitTest1.FailsAlways"
+        run: |
+          dotnet retest -- ./src/Sample/ --filter "FullyQualifiedName!=Sample.UnitTest1.FailsAlways"
+          dotnet retest -- ./src/Sample2/ --filter "FullyQualifiedName!=Sample.UnitTest1.FailsAlways"
 
       - name: 🐛 logs
         uses: actions/upload-artifact@v4

--- a/dotnet-retest.sln
+++ b/dotnet-retest.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-retest", "src\dotnet
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample", "src\Sample\Sample.csproj", "{5A647D73-B3A8-49E8-A8A3-AC3CAD00DF48}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample2", "src\Sample2\Sample2.csproj", "{0F3664F5-4955-4D04-9DBA-FA144E3621F1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{5A647D73-B3A8-49E8-A8A3-AC3CAD00DF48}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5A647D73-B3A8-49E8-A8A3-AC3CAD00DF48}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5A647D73-B3A8-49E8-A8A3-AC3CAD00DF48}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F3664F5-4955-4D04-9DBA-FA144E3621F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F3664F5-4955-4D04-9DBA-FA144E3621F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F3664F5-4955-4D04-9DBA-FA144E3621F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F3664F5-4955-4D04-9DBA-FA144E3621F1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Sample/Sample.csproj
+++ b/src/Sample/Sample.csproj
@@ -4,9 +4,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sample/UnitTest1.cs
+++ b/src/Sample/UnitTest1.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+
 namespace Sample;
 
 public class UnitTest1
@@ -14,6 +16,23 @@ public class UnitTest1
     public void Test1(int value)
     {
         Assert.True(value > 0);
+    }
+
+    [Theory]
+    [InlineData("this test, shouldn't break")]
+    [InlineData("successful case")]
+    public void ParameterEscapingRetries(string value)
+    {
+        // get a simple sha from the string to use as filename using the hex value from the sha1 of the value
+        var file = "failed" + string.Concat(SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(value)).Select(b => b.ToString("x2"))) + ".txt";
+
+        if (!File.Exists(file))
+        {
+            File.WriteAllText(file, "");
+            Assert.Fail("Fails once");
+        }
+
+        File.Delete(file);
     }
 
     [Fact]

--- a/src/Sample2/NUnitTest.cs
+++ b/src/Sample2/NUnitTest.cs
@@ -1,0 +1,26 @@
+﻿using System.Security.Cryptography;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Assert;
+
+namespace Sample;
+
+[TestFixture]
+public class NUnitTest
+{
+    [TestCase("this test, shouldn't break")]
+    [TestCase("successful case")]
+    public void ParameterEscapingRetries(string value)
+    {
+        // get a simple sha from the string to use as filename using the hex value from the sha1 of the value
+        var file = "failed" + string.Concat(SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(value)).Select(b => b.ToString("x2"))) + ".txt";
+
+        if (!File.Exists(file))
+        {
+            File.WriteAllText(file, "");
+            Assert.Fail("Fails once");
+        }
+
+        File.Delete(file);
+    }
+
+}

--- a/src/Sample2/Sample2.csproj
+++ b/src/Sample2/Sample2.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/dotnet-retest/Program.cs
+++ b/src/dotnet-retest/Program.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Devlooped;
@@ -12,6 +14,9 @@ using Spectre.Console;
 using Spectre.Console.Cli;
 using Spectre.Console.Cli.Help;
 using Spectre.Console.Rendering;
+
+if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    Console.InputEncoding = Console.OutputEncoding = Encoding.UTF8;
 
 var app = new CommandApp<RetestCommand>();
 

--- a/src/dotnet-retest/Properties/launchSettings.json
+++ b/src/dotnet-retest/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "dotnet-retest": {
       "commandName": "Project",
       "commandLineArgs": "-- --filter \"FullyQualifiedName!=Sample.UnitTest1.FailsAlways\"",
-      "workingDirectory": "..\\Sample"
+      "workingDirectory": "..\\Sample2"
     }
   }
 }

--- a/src/dotnet-retest/RetestCommand.cs
+++ b/src/dotnet-retest/RetestCommand.cs
@@ -259,7 +259,7 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
     async Task<BufferedCommandResult> RunTestsAsync(string dotnet, List<string> args, IEnumerable<string> failed, IProgress<string> progress)
     {
         var finalArgs = args;
-        var filter = string.Join('|', failed.Select(failed => $"FullyQualifiedName~{failed}"));
+        var filter = string.Join('|', failed.Select(failed => $"FullyQualifiedName~{failed.Replace("\"", "%22").Replace(",", "%2C").Replace("(", "\\(").Replace(")", "\\)")}"));
         if (filter.Length > 0)
         {
             var parsed = command.Parse(args);


### PR DESCRIPTION
Improve escaping sequences in test filters

This broke in parameterized test retries in NUnit (which seems to always do a pre-enumeration in this case).

Fixes #89