### PR TITLE
Render failing tests in verbose setting

### DIFF
--- a/src/dotnet-retest/Properties/launchSettings.json
+++ b/src/dotnet-retest/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "dotnet-retest": {
       "commandName": "Project",
-      "commandLineArgs": "-- --filter \"FullyQualifiedName!=Sample.UnitTest1.FailsAlways\"",
-      "workingDirectory": "..\\Sample2"
+      "commandLineArgs": "-v verbose -- --filter \"FullyQualifiedName!=Sample.UnitTest1.FailsAlways\"",
+      "workingDirectory": "..\\Sample"
     }
   }
 }

--- a/src/dotnet-retest/RetestCommand.cs
+++ b/src/dotnet-retest/RetestCommand.cs
@@ -15,6 +15,7 @@ using NuGet.Packaging;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using Spectre.Console.Rendering;
+using static System.Net.Mime.MediaTypeNames;
 using static Devlooped.TrxCommand;
 using static Spectre.Console.AnsiConsole;
 
@@ -192,6 +193,12 @@ public partial class RetestCommand : AsyncCommand<RetestCommand.RetestSettings>
                 finally
                 {
                     task.StopTask();
+                }
+
+                if (settings.Verbosity == Verbosity.Verbose)
+                {
+                    foreach (var test in failed)
+                        MarkupLine($"\t:cross_mark: #{attempts} {test}");
                 }
             }
         });


### PR DESCRIPTION
This makes it easier to inspect which tests are flaky and being retried as they are retried.

<img width="788" height="232" alt="image" src="https://github.com/user-attachments/assets/84c7e4ef-c610-4682-a219-cdb908e16eab" />


Fixes #86