### PR TITLE
⬆️ Bump files with dotnet-file sync

### DIFF
--- a/.netconfig
+++ b/.netconfig
@@ -52,8 +52,8 @@
 	weak
 [file ".github/workflows/includes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/includes.yml
-	sha = 85829f2510f335f4a411867f3dbaaa116c3ab3de
-	etag = 086f6b6316cc6ea7089c0dcc6980be519e6ed6e6201e65042ef41b82634ec0ee
+	sha = 6a6de0580b40e305f7a0f41b406d4aabaa0756fe
+	etag = 1a5cd7a883700c328105910cc212f5f8c9f3759fc1af023e048a9f486da794c1
 	weak
 [file ".github/workflows/publish.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/publish.yml
@@ -135,3 +135,4 @@
 	url = https://github.com/devlooped/.github/blob/main/osmfeula.txt
 	etag = 91ea15c07bfd784036c6ca931f5b2df7e9767b8367146d96c79caef09d63899f
 	weak
+	sha = 666a2a7c315f72199c418f11482a950fc69a8901


### PR DESCRIPTION
# devlooped/oss

- Fix path pattern for markdown files in workflow https://github.com/devlooped/oss/commit/6a6de05